### PR TITLE
improve test on CI and Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,19 +26,6 @@ jobs:
         name: linux-x64
         path: target/release/libgsqlite.so
 
-  build-linux-x86:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install target
-      run: sudo apt install -y gcc-multilib && rustup target install i686-unknown-linux-gnu
-    - name: Build release
-      run: cargo build --release --target=i686-unknown-linux-gnu
-    - uses: actions/upload-artifact@v3
-      with:
-        name: linux-x86
-        path: target/i686-unknown-linux-gnu/release/libgsqlite.so
-
   build-windows-x64:
     runs-on: windows-latest
     steps:
@@ -53,19 +40,6 @@ jobs:
       with:
         name: windows-x64
         path: target/release/gsqlite.dll
-
-  build-windows-x86:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install target
-      run: rustup target add i686-pc-windows-msvc
-    - name: Build release
-      run: cargo build --release --target=i686-pc-windows-msvc
-    - uses: actions/upload-artifact@v3
-      with:
-        name: windows-x86
-        path: target/i686-pc-windows-msvc/release/gsqlite.dll
 
   build-macos-x64:
     runs-on: macos-latest
@@ -85,7 +59,7 @@ jobs:
   create-release:
 
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [ build-linux-x64, build-linux-x86, build-windows-x64, build-windows-x86, build-macos-x64 ]
+    needs: [ build-linux-x64, build-windows-x64, build-macos-x64 ]
     runs-on: ubuntu-latest
 
     steps:
@@ -96,12 +70,8 @@ jobs:
         path: .
     - name: Archive linux-x64
       run: mv linux-x64/libgsqlite.so ./libgsqlite.so && tar -zcvf libgsqlite-linux-x64.tar.gz libgsqlite.so && rm libgsqlite.so
-    - name: Archive linux-x86
-      run: mv linux-x86/libgsqlite.so ./libgsqlite.so && tar -zcvf libgsqlite-linux-x86.tar.gz libgsqlite.so && rm libgsqlite.so
     - name: Archive windows-x64
       run: mv windows-x64/gsqlite.dll ./gsqlite.dll && zip gsqlite-windows-x64.zip gsqlite.dll && rm gsqlite.dll
-    - name: Archive windows-x86
-      run: mv windows-x86/gsqlite.dll ./gsqlite.dll && zip gsqlite-windows-x86.zip gsqlite.dll && rm gsqlite.dll
     - name: Archive macos-x64
       run: mv macos-x64/libgsqlite.dylib ./libgsqlite.dylib && zip libgsqlite-macos-x64.zip libgsqlite.dylib && rm libgsqlite.dylib
 
@@ -127,16 +97,6 @@ jobs:
         asset_name: libgsqlite-linux-x64.tar.gz
         asset_content_type: application/octet-stream
 
-    - name: Upload linux-x86 artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./libgsqlite-linux-x86.tar.gz
-        asset_name: libgsqlite-linux-x86.tar.gz
-        asset_content_type: application/octet-stream
-
     - name: Upload windows-x64 artifact
       uses: actions/upload-release-asset@v1
       env:
@@ -145,16 +105,6 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./gsqlite-windows-x64.zip
         asset_name: gsqlite-windows-x64.zip
-        asset_content_type: application/octet-stream
-
-    - name: Upload windows-x86 artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./gsqlite-windows-x86.zip
-        asset_name: gsqlite-windows-x86.zip
         asset_content_type: application/octet-stream
 
     - name: Upload macos-x64 artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Build debug
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --skip test_extension
     - name: Build release
       run: cargo build --release
     - uses: actions/upload-artifact@v3
@@ -46,7 +46,7 @@ jobs:
     - name: Build debug
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --skip test_extension
     - name: Build release
       run: cargo build --release
     - uses: actions/upload-artifact@v3
@@ -74,7 +74,7 @@ jobs:
     - name: Build debug
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --skip test_extension
     - name: Build release
       run: cargo build --release
     - uses: actions/upload-artifact@v3

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 authors = ["kaoru <679719+0x6b@users.noreply.github.com>"]
 
 [dependencies]
-oauth2 = "4.2.3"
+oauth2 = { version = "4.2.3", features = ["rustls-tls"] }
 open = "3.0.2"
-reqwest = { version = "0.11.11" }
+reqwest = { version = "0.11.11", features = ["rustls"] }
 serde = { version = "1.0.140", features = ["serde_derive"] }
 serde_json = "1.0.82"
 typed-builder = "0.10.0"

--- a/lib/src/module.rs
+++ b/lib/src/module.rs
@@ -325,10 +325,7 @@ fn create_declare_table_statement(columns: Vec<String>) -> CString {
 mod tests {
     use crate::module::create_declare_table_statement;
     use rusqlite::{Connection, LoadExtensionGuard};
-    use std::{
-        ffi::CString,
-        {error::Error, path::PathBuf},
-    };
+    use std::{ffi::CString, {error::Error, path::PathBuf}, env};
 
     #[derive(Debug, PartialEq)]
     struct Employee {
@@ -360,9 +357,18 @@ mod tests {
         let conn = Connection::open_in_memory()?;
         load_my_extension(&conn)?;
 
-        let id = env!("LIBGSQLITE_GOOGLE_CLIENT_TEST_ID");
-        let sheet = env!("LIBGSQLITE_GOOGLE_CLIENT_TEST_SHEET");
-        let range = env!("LIBGSQLITE_GOOGLE_CLIENT_TEST_RANGE");
+        let id = match env::var("LIBGSQLITE_GOOGLE_CLIENT_ID") {
+            Ok(v) => v,
+            Err(_) => panic!("Environment variable LIBGSQLITE_GOOGLE_CLIENT_ID is not set"),
+        };
+        let sheet = match env::var("LIBGSQLITE_GOOGLE_CLIENT_TEST_SHEET") {
+            Ok(v) => v,
+            Err(_) => panic!("Environment variable LIBGSQLITE_GOOGLE_CLIENT_TEST_SHEET is not set"),
+        };
+        let range = match env::var("LIBGSQLITE_GOOGLE_CLIENT_TEST_RANGE") {
+            Ok(v) => v,
+            Err(_) => panic!("Environment variable LIBGSQLITE_GOOGLE_CLIENT_TEST_RANGE is not set"),
+        };
         conn.execute(
             format!(
                 r#"CREATE VIRTUAL TABLE employees USING gsqlite(ID '{}', SHEET '{}', RANGE '{}');"#,


### PR DESCRIPTION
Use run-time environment variables instead of compile time to avoid errors while compiling on CI environment. Also skip integration test which needs Google Cloud setup.
